### PR TITLE
docs: mention PostgreSQL 17 in supported version tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ services:
       POSTGRES_PASSWORD: password
 ```
 
-- Images are tagged by the major PostgreSQL version supported: `12`, `13`, `14`, `15` or `16`.
+- Images are tagged by the major PostgreSQL version supported: `12`, `13`, `14`, `15`, `16` or `17`.
 - The `SCHEDULE` variable determines backup frequency. See go-cron schedules documentation [here](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules). Omit to run the backup immediately and then exit.
 - If `PASSPHRASE` is provided, the backup will be encrypted using GPG.
 - Run `docker exec <container name> bash backup.sh` to trigger a backup ad-hoc.


### PR DESCRIPTION
Le support de PostgreSQL 17 est déjà en place dans la CI (`build-and-push-images.yml` et `integration-tests.yml` construisent et testent l'image `:17`), mais le README listait encore uniquement les tags `12`–`16`.

Cette MR met à jour la ligne des versions supportées pour inclure `17`.